### PR TITLE
feat: add translate button on text selection

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -3,17 +3,19 @@
     "name": "AI Translator",
     "version": "0.2.3",
     "description": "Translate text and pages using customizable AI models.",
-    "permissions": [
-        "contextMenus",
-        "scripting",
-        "storage",
-        "activeTab"
+    "permissions": ["contextMenus", "scripting", "storage", "activeTab"],
+    "host_permissions": ["https://*/*", "http://*/*"],
+    "content_scripts": [
+        {
+            "matches": ["https://*/*", "http://*/*"],
+            "js": ["purify.min.js", "content.js"],
+            "css": ["styles.css"],
+            "run_at": "document_idle",
+            "all_frames": true
+        }
     ],
-    "host_permissions": [],
     "background": {
-        "scripts": [
-            "background.js"
-        ]
+        "scripts": ["background.js"]
     },
     "options_page": "options.html",
     "action": {
@@ -37,9 +39,7 @@
             "id": "ai-translator@adin.dev",
             "strict_min_version": "142.0",
             "data_collection_permissions": {
-                "required": [
-                    "none"
-                ]
+                "required": ["none"]
             }
         }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,13 +3,17 @@
     "name": "AI Translator",
     "version": "0.2.3",
     "description": "Translate text and pages using customizable AI models.",
-    "permissions": [
-        "contextMenus",
-        "scripting",
-        "storage",
-        "activeTab"
+    "permissions": ["contextMenus", "scripting", "storage", "activeTab"],
+    "host_permissions": ["https://*/*", "http://*/*"],
+    "content_scripts": [
+        {
+            "matches": ["https://*/*", "http://*/*"],
+            "js": ["purify.min.js", "content.js"],
+            "css": ["styles.css"],
+            "run_at": "document_idle",
+            "all_frames": true
+        }
     ],
-    "host_permissions": [],
     "background": {
         "service_worker": "background.js"
     },

--- a/options.html
+++ b/options.html
@@ -34,6 +34,25 @@
                 </p>
             </div>
 
+            <div class="mb-6">
+                <label class="flex items-start gap-2">
+                    <input
+                        type="checkbox"
+                        id="show-translate-button-on-selection"
+                        class="mt-1"
+                    />
+                    <span>
+                        <span class="block text-sm font-medium text-gray-700">
+                            Show Translate button on selection
+                        </span>
+                        <span class="block text-xs text-gray-500">
+                            Shows a small Translate button when you select text on any
+                            page. Requires site access on all pages.
+                        </span>
+                    </span>
+                </label>
+            </div>
+
             <form id="settings-form">
                 <div id="basic-settings" class="hidden">
                     <div class="mb-4">

--- a/styles.css
+++ b/styles.css
@@ -10,15 +10,27 @@
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15); /* Softer shadow */
     max-width: 350px; /* Max width */
     min-width: 150px; /* Min width */
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-        Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif; /* System font */
+    font-family:
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Oxygen,
+        Ubuntu,
+        Cantarell,
+        "Open Sans",
+        "Helvetica Neue",
+        sans-serif; /* System font */
     font-size: 14px;
     color: #222; /* Darker text */
     line-height: 1.5;
     /* Add a subtle animation */
     opacity: 0;
     transform: translateY(5px);
-    transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+    transition:
+        opacity 0.2s ease-out,
+        transform 0.2s ease-out;
     pointer-events: auto; /* Make sure it's interactive */
 }
 
@@ -52,4 +64,48 @@
 /* Ensure body allows absolute positioning */
 body {
     position: relative;
+}
+
+#ai-translator-selection-translate-button {
+    position: absolute;
+    z-index: 2147483647 !important;
+    display: none;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: #4f46e5;
+    color: #ffffff;
+    border: 0;
+    border-radius: 9999px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+    font-family:
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Oxygen,
+        Ubuntu,
+        Cantarell,
+        "Open Sans",
+        "Helvetica Neue",
+        sans-serif;
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+}
+
+#ai-translator-selection-translate-button:hover {
+    background: #4338ca;
+}
+
+#ai-translator-selection-translate-button:active {
+    transform: translateY(1px);
+}
+
+#ai-translator-selection-translate-button svg {
+    width: 14px;
+    height: 14px;
+    fill: currentColor;
 }


### PR DESCRIPTION
## Summary
- Adds a DeepL-style floating \"Translate\" button that appears below selected text.
- Default-on for existing installs via storage migration; toggle available in Options.
- Loads content script on all http/https pages (adds host permissions) to detect selections.

## Notes
- This change adds broad host access (http/https) so selection detection works without a user gesture.