### PR TITLE
feat: add Groq provider support in Advanced Settings

### DIFF
--- a/options.html
+++ b/options.html
@@ -177,6 +177,7 @@
                             <option value="openai">OpenAI</option>
                             <option value="anthropic">Anthropic Claude</option>
                             <option value="google">Google Gemini</option>
+                            <option value="groq">Groq</option>
                             <option value="grok">Grok (xAI)</option>
                             <option value="openrouter">OpenRouter</option>
                             <option value="deepseek">DeepSeek</option>

--- a/options.js
+++ b/options.js
@@ -43,6 +43,7 @@ const PROVIDERS = [
     "openai",
     "anthropic",
     "google",
+    "groq",
     "grok",
     "openrouter",
     "deepseek",
@@ -64,6 +65,10 @@ const PROVIDER_DEFAULTS = {
     google: {
         apiEndpoint: "https://generativelanguage.googleapis.com/v1beta",
         modelName: "gemini-3-flash-preview",
+    },
+    groq: {
+        apiEndpoint: "https://api.groq.com/openai/v1/chat/completions",
+        modelName: "qwen/qwen3-32b",
     },
     grok: {
         apiEndpoint: "https://api.x.ai/v1/chat/completions",


### PR DESCRIPTION
## Summary
- Add Groq as a selectable provider in Advanced Settings
- Default endpoint: `https://api.groq.com/openai/v1/chat/completions`
- Default model: `qwen/qwen3-32b`
- Filters out `<think>...</think>` blocks from reasoning model responses
- Provider lists and defaults synchronized between `background.js` and `options.js`

Closes #13

## Test plan
- [ ] Load extension unpacked
- [ ] Open options, switch to Advanced mode
- [ ] Select Groq provider
- [ ] Enter Groq API key
- [ ] Verify endpoint defaults correctly
- [ ] Translate selected text and verify response
- [ ] Verify no thinking output appears in translation