### PR TITLE
Remove redundant activeTab permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ We value your privacy. This extension operates client-side and does not collect 
 
 **Permissions:**
 - `host_permissions` (`https://*/*`, `http://*/*`): Allow the selection button and page translation to run on any site you visit.
-- `activeTab`: Grants temporary access when you explicitly trigger a translation.
 - `storage`: Used to save your settings locally.
 - `scripting`: Used to inject translation scripts into the page when requested.
 

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -3,7 +3,7 @@
     "name": "AI Translator",
     "version": "0.2.3",
     "description": "Translate text and pages using customizable AI models.",
-    "permissions": ["contextMenus", "scripting", "storage", "activeTab"],
+    "permissions": ["contextMenus", "scripting", "storage"],
     "host_permissions": ["https://*/*", "http://*/*"],
     "content_scripts": [
         {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "AI Translator",
     "version": "0.2.3",
     "description": "Translate text and pages using customizable AI models.",
-    "permissions": ["contextMenus", "scripting", "storage", "activeTab"],
+    "permissions": ["contextMenus", "scripting", "storage"],
     "host_permissions": ["https://*/*", "http://*/*"],
     "content_scripts": [
         {


### PR DESCRIPTION
## Summary
- Removed `activeTab` from `manifest.json` and `manifest.firefox.json`
- Updated README permissions section to remove the `activeTab` reference

The `activeTab` permission is redundant because all-site `host_permissions` and always-on content scripts already grant the necessary access.

Closes #16