### PR TITLE
Add exponential backoff retry for rate limit errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Translator",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "description": "Translate text and pages using customizable AI models.",
   "permissions": [
     "contextMenus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-translator",
-  "version": "0.4.0",
+  "version": "0.6.1",
   "description": "Translate text and pages using customizable AI models.",
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/shared/constants/settings.ts
+++ b/src/shared/constants/settings.ts
@@ -52,6 +52,12 @@ export const HTML_TRANSLATION_PORT_NAME = "htmlTranslation";
 export const STREAM_UPDATE_THROTTLE_MS = 120;
 export const STREAM_KEEP_ALIVE_INTERVAL_MS = 20000;
 
+// Rate limit retry configuration
+export const RATE_LIMIT_MAX_RETRIES = 5;
+export const RATE_LIMIT_BASE_DELAY_MS = 1000;
+export const RATE_LIMIT_MAX_DELAY_MS = 60000;
+export const RATE_LIMIT_BACKOFF_MULTIPLIER = 2;
+
 export function buildStandardPrompt(
     userInstructions: string,
     textToTranslate: string,


### PR DESCRIPTION
## Summary
- Add exponential backoff retry logic for API rate limit errors (e.g., Groq's TPM limits)
- Detects rate limits via HTTP 429 status or error message patterns
- Parses "try again in X seconds" hints from error messages when available
- Falls back to exponential backoff (1s, 2s, 4s...) with jitter, capped at 60s
- Retries up to 5 times for rate limits only (other errors fail immediately)

## Test plan
- [ ] Trigger rate limit on Groq by translating a large page
- [ ] Verify retry messages appear in console with appropriate delays
- [ ] Verify translation completes after rate limit clears
- [ ] Verify non-rate-limit errors still fail immediately

Fixes rate limit errors preventing full-page translation from completing.

**Version:** 0.6.1