### PR TITLE
feat: enable all providers in Basic mode

### DIFF
--- a/assets/options.html
+++ b/assets/options.html
@@ -287,19 +287,7 @@
                             id="api-type"
                             name="api-type"
                             class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white"
-                        >
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic Claude</option>
-                            <option value="google">Google Gemini</option>
-                            <option value="groq">Groq</option>
-                            <option value="grok">Grok (xAI)</option>
-                            <option value="openrouter">OpenRouter</option>
-                            <option value="deepseek">DeepSeek</option>
-                            <option value="mistral">Mistral AI</option>
-                            <option value="qwen">Qwen (Alibaba)</option>
-                            <option value="cerebras">Cerebras</option>
-                            <option value="ollama">Ollama (Local)</option>
-                        </select>
+                        ></select>
                         <p class="text-xs text-gray-500 mt-1">
                             <span data-i18n="optionsAdvancedProviderHelp">
                                 Select the format your endpoint expects.

--- a/assets/options.html
+++ b/assets/options.html
@@ -201,11 +201,7 @@
                             id="basic-provider"
                             name="basic-provider"
                             class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white"
-                        >
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic Claude</option>
-                            <option value="google">Google Gemini</option>
-                        </select>
+                        ></select>
                         <p
                             class="text-xs text-gray-500 mt-1"
                             data-i18n="optionsBasicProviderHelp"

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -57,7 +57,6 @@ import {
 import {
     PROVIDERS,
     PROVIDER_DEFAULTS,
-    BASIC_PROVIDERS,
     type Provider,
 } from "../shared/constants/providers";
 import {

--- a/src/extension/options.ts
+++ b/src/extension/options.ts
@@ -449,14 +449,14 @@ function populateTargetLanguageDropdown(selectEl: HTMLSelectElement): void {
     selectEl.appendChild(customOption);
 }
 
-function populateBasicProviderDropdown(): void {
-    if (!basicProviderSelect) return;
-    basicProviderSelect.textContent = "";
+function populateProviderDropdown(select: HTMLSelectElement | null): void {
+    if (!select) return;
+    select.textContent = "";
     for (const id of PROVIDERS) {
         const option = document.createElement("option");
         option.value = id;
         option.textContent = PROVIDER_DISPLAY_NAMES[id];
-        basicProviderSelect.appendChild(option);
+        select.appendChild(option);
     }
 }
 
@@ -855,9 +855,7 @@ function buildGoogleModelsUrl(endpoint: string): string {
 }
 
 function getProviderDisplayName(provider: Provider): string {
-    const option = apiTypeSelect?.querySelector(`option[value="${provider}"]`);
-    const label = option?.textContent?.trim() || "";
-    return label || provider;
+    return PROVIDER_DISPLAY_NAMES[provider] || provider;
 }
 
 function resolveModelFetchSettings(provider: Provider): {
@@ -1768,7 +1766,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     applyTheme(uiTheme);
     updateThemeSelectionUI(uiTheme);
 
-    populateBasicProviderDropdown();
+    populateProviderDropdown(basicProviderSelect);
+    populateProviderDropdown(apiTypeSelect);
     populateBasicLanguageDropdown();
     populateAdvancedLanguageDropdown();
     loadSettings();
@@ -1778,8 +1777,6 @@ document.addEventListener("DOMContentLoaded", async () => {
             settingsMode = advancedModeToggle.checked
                 ? SETTINGS_MODE_ADVANCED
                 : SETTINGS_MODE_BASIC;
-
-            const isBasic = settingsMode === SETTINGS_MODE_BASIC;
 
             const activeProvider = apiTypeSelect.value;
 

--- a/src/extension/options.ts
+++ b/src/extension/options.ts
@@ -7,7 +7,7 @@ import {
 import {
     PROVIDERS,
     PROVIDER_DEFAULTS,
-    BASIC_PROVIDERS,
+    PROVIDER_DISPLAY_NAMES,
     CEREBRAS_SUPPORTED_MODELS,
     canonicalizeProviderModelName,
     resolveProviderDefaults,
@@ -447,6 +447,17 @@ function populateTargetLanguageDropdown(selectEl: HTMLSelectElement): void {
     customOption.value = CUSTOM_TARGET_LANGUAGE_OPTION_VALUE;
     customOption.textContent = t("optionsCustomOptionLabel", "Custom…");
     selectEl.appendChild(customOption);
+}
+
+function populateBasicProviderDropdown(): void {
+    if (!basicProviderSelect) return;
+    basicProviderSelect.textContent = "";
+    for (const id of PROVIDERS) {
+        const option = document.createElement("option");
+        option.value = id;
+        option.textContent = PROVIDER_DISPLAY_NAMES[id];
+        basicProviderSelect.appendChild(option);
+    }
 }
 
 function populateBasicLanguageDropdown(): void {
@@ -1514,19 +1525,10 @@ async function loadSettings(): Promise<void> {
                 ? (result.apiType as Provider)
                 : "openai";
 
-        if (
-            settingsMode === SETTINGS_MODE_BASIC &&
-            !BASIC_PROVIDERS.includes(initialProvider as any)
-        ) {
-            initialProvider = "openai";
-        }
-
         apiTypeSelect.value = initialProvider;
 
         if (basicProviderSelect) {
-            basicProviderSelect.value = BASIC_PROVIDERS.includes(initialProvider as any)
-                ? initialProvider
-                : "openai";
+            basicProviderSelect.value = initialProvider;
         }
 
         applyProviderToForm(initialProvider);
@@ -1579,9 +1581,7 @@ function applyBasicSettingsToUI(provider: string): void {
     const settings = providerSettings[provider] || resolveProviderDefaults(provider);
 
     if (basicProviderSelect) {
-        basicProviderSelect.value = BASIC_PROVIDERS.includes(provider as any)
-            ? provider
-            : "openai";
+        basicProviderSelect.value = PROVIDERS.includes(provider as Provider) ? provider : "openai";
     }
 
     if (basicApiKeyInput) {
@@ -1611,7 +1611,7 @@ async function saveSetting(): Promise<void> {
 
     if (isBasic) {
         const selectedProvider = basicProviderSelect?.value || "openai";
-        const provider = BASIC_PROVIDERS.includes(selectedProvider as any)
+        const provider: Provider = PROVIDERS.includes(selectedProvider as Provider)
             ? (selectedProvider as Provider)
             : "openai";
 
@@ -1768,6 +1768,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     applyTheme(uiTheme);
     updateThemeSelectionUI(uiTheme);
 
+    populateBasicProviderDropdown();
     populateBasicLanguageDropdown();
     populateAdvancedLanguageDropdown();
     loadSettings();
@@ -1780,16 +1781,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
             const isBasic = settingsMode === SETTINGS_MODE_BASIC;
 
-            let activeProvider = apiTypeSelect.value;
-            if (isBasic && !BASIC_PROVIDERS.includes(activeProvider as any)) {
-                activeProvider = "openai";
-                apiTypeSelect.value = activeProvider;
-            }
+            const activeProvider = apiTypeSelect.value;
 
             if (basicProviderSelect) {
-                basicProviderSelect.value = BASIC_PROVIDERS.includes(
-                    activeProvider as any,
-                )
+                basicProviderSelect.value = PROVIDERS.includes(activeProvider as Provider)
                     ? activeProvider
                     : "openai";
             }
@@ -1819,7 +1814,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (basicProviderSelect) {
         basicProviderSelect.addEventListener("change", () => {
             const provider = basicProviderSelect.value;
-            const safeProvider = BASIC_PROVIDERS.includes(provider as any)
+            const safeProvider: Provider = PROVIDERS.includes(provider as Provider)
                 ? (provider as Provider)
                 : "openai";
 

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -14,9 +14,19 @@ export const PROVIDERS = [
 
 export type Provider = (typeof PROVIDERS)[number];
 
-export const BASIC_PROVIDERS = ["openai", "anthropic", "google"] as const;
-
-export type BasicProvider = (typeof BASIC_PROVIDERS)[number];
+export const PROVIDER_DISPLAY_NAMES: Record<Provider, string> = {
+    openai: "OpenAI",
+    anthropic: "Anthropic Claude",
+    google: "Google Gemini",
+    groq: "Groq",
+    grok: "Grok (xAI)",
+    openrouter: "OpenRouter",
+    deepseek: "DeepSeek",
+    mistral: "Mistral AI",
+    qwen: "Qwen (Alibaba)",
+    cerebras: "Cerebras",
+    ollama: "Ollama (Local)",
+};
 
 export const CEREBRAS_SUPPORTED_MODELS = [
     "llama3.1-8b",


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `BASIC_PROVIDERS` subset (`openai`, `anthropic`, `google`) with the full `PROVIDERS` list so every supported provider is selectable in Basic mode
- Adds a `PROVIDER_DISPLAY_NAMES` map in `providers.ts` and populates the basic-provider `<select>` dynamically to prevent drift between HTML and constants
- Removes all forced-fallback-to-OpenAI guardrails that rejected valid providers in Basic mode

## Test plan
- [ ] Open options page in Basic mode — verify all 11 providers appear in the dropdown
- [ ] Select each provider, enter an API key, save — confirm provider choice persists on reload
- [ ] Switch between Basic and Advanced mode — confirm provider selection carries over without resetting to OpenAI
- [ ] Existing users with `openai`/`anthropic`/`google` saved should see no behavior change

Closes #27